### PR TITLE
allow custom depreciation expense account

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,25 @@ Then this plugin will transform the transaction into:
 
 At last, the balance of the account `Assets:Car:ModelX` is 80000 USD.
 
+To change the depreciation expense account, add the `depreciate_account` meta to the `open` statement of the depreciated asset account:
+```beancount
+1900-01-01 open Assets:Car:ModelX  EUR
+  depreciate_account: "Expenses:Car:Value"
+
+2022-03-31 * "Tesla" "Model X"
+  Liababilies:CreditCard:0001    -200000 USD
+  Assets:Car:ModelX
+    depreciate: "5 Year /Yearly =80000"
+
+
+; generated transation
+2022-03-31 * "Tesla" "Model X Depreciated(1/5)"
+  Assets:Car:ModelX    -24000 USD
+  Expenses:Car:Value
+
+; ...
+```
+
 ### Config string in meta
 
 All settings follow the same rules. These are some examples:

--- a/beancount_periodic/depreciate.py
+++ b/beancount_periodic/depreciate.py
@@ -1,3 +1,6 @@
+from typing import Dict, Tuple
+
+import beancount.core.getters
 from beancount.core import data, account, account_types
 from beancount.parser import options
 
@@ -7,10 +10,31 @@ from .common.utils import select_periodic_posting_groups
 __plugins__ = ('depreciate',)
 
 
+def get_depreciation_account(
+        accounts_open_close: Dict[str, Tuple[beancount.core.data.Open, beancount.core.data.Close]],
+        expenses_parent: str,
+        asset_account: beancount.core.data.Account,
+) -> str:
+    new_account = str.join(
+        account.sep,
+        [expenses_parent, 'Depreciation', account.sans_root(asset_account)]
+    )
+
+    asset_account_open_statement = accounts_open_close.get(asset_account, None)[0]
+    open_meta = asset_account_open_statement.meta
+    depreciate_account = open_meta.get('depreciate_account', None)
+
+    if depreciate_account:
+        return depreciate_account
+
+    return new_account
+
+
 def depreciate(entries: data.Entries, unused_options_map, config_string=""):
     new_entries = []
     errors = []
     account_types_option = options.get_account_types(unused_options_map)
+    accounts_open_close = beancount.core.getters.get_account_open_close(entries)
     for entry in entries:
         if isinstance(entry, data.Transaction):
             selected_postings_groups = select_periodic_posting_groups(entry, 'depreciate', errors)
@@ -19,9 +43,11 @@ def depreciate(entries: data.Entries, unused_options_map, config_string=""):
                 for i, config, config_str in selected_postings:
                     posting: data.Posting = entry.postings[i]
                     if account_types.is_account_type(account_types_option.assets, posting.account):
-                        new_account = str.join(account.sep,
-                                               [account_types_option.expenses, 'Depreciation',
-                                                account.sans_root(posting.account)])
+                        new_account = get_depreciation_account(
+                            accounts_open_close,
+                            account_types_option.expenses,
+                            posting.account
+                        )
                     else:
                         continue
                     new_postings_config.append((config, posting, new_account))


### PR DESCRIPTION
This pull request allows users to change the expense account for depreciating assets by specifying an account in the `depreciate_account` meta of the asset account's `open` statement.

Background: I want my car's depreciation to be tracked as a child account of `Expenses:Car`.