### PR TITLE
add `generate_until` configuration option preventing creation of transactions occurring after a given date

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ plugin "beancount_periodic.recur"
 ```beancount
 2022-03-31 * "Provider" "Net Fee"
   recur: "1 Year /Monthly"
-  Liababilies:CreditCard:0001    -50 USD
+  Liabilities:CreditCard:0001    -50 USD
   Expenses:Home:CommunicationFee
 ```
 
@@ -26,21 +26,21 @@ Then this plugin will transform the transaction into:
 
 ```beancount
 2022-03-31 * "Provider" "Net Fee Recurring(1/12)"
-  Liababilies:CreditCard:0001    -50 USD
+  Liabilities:CreditCard:0001    -50 USD
   Expenses:Home:CommunicationFee
 
 2022-04-30 * "Provider" "Net Fee Recurring(2/12)"
-  Liababilies:CreditCard:0001    -50 USD
+  Liabilities:CreditCard:0001    -50 USD
   Expenses:Home:CommunicationFee
 
 2022-05-31 * "Provider" "Net Fee Recurring(3/12)"
-  Liababilies:CreditCard:0001    -50 USD
+  Liabilities:CreditCard:0001    -50 USD
   Expenses:Home:CommunicationFee
 
 ;...
 
 2023-02-28 * "Provider" "Net Fee Recurring(12/12)"
-  Liababilies:CreditCard:0001    -50 USD
+  Liabilities:CreditCard:0001    -50 USD
   Expenses:Home:CommunicationFee
 ```
 
@@ -53,7 +53,7 @@ plugin "beancount_periodic.amortize"
 
 ```beancount
 2022-03-31 * "Landlord" "2022-04 Rent"
-  Liababilies:CreditCard:0001    -12000 USD
+  Liabilities:CreditCard:0001    -12000 USD
   Expenses:Home:Rent
     amortize: "1 Year @2022-04-01 /Monthly"
 ```
@@ -62,7 +62,7 @@ Then this plugin will transform the transaction into:
 
 ```beancount
 2022-03-31 * "Landlord" "2022-04 Rent"
-  Liababilies:CreditCard:0001    -12000 USD
+  Liabilities:CreditCard:0001    -12000 USD
   Equity:Amortization:Home:Rent
     amortize: "1 Year @2022-04-01 /Monthly"
 
@@ -94,7 +94,7 @@ plugin "beancount_periodic.depreciate"
 
 ```beancount
 2022-03-31 * "Tesla" "Model X"
-  Liababilies:CreditCard:0001    -200000 USD
+  Liabilities:CreditCard:0001    -200000 USD
   Assets:Car:ModelX
     depreciate: "5 Year /Yearly =80000"
 ```
@@ -103,7 +103,7 @@ Then this plugin will transform the transaction into:
 
 ```beancount
 2022-03-31 * "Tesla" "Model X"
-  Liababilies:CreditCard:0001    -200000 USD
+  Liabilities:CreditCard:0001    -200000 USD
   Assets:Car:ModelX
     depreciate: "5 Year /Yearly =80000"
   
@@ -130,7 +130,7 @@ To change the depreciation expense account, add the `depreciate_account` meta to
   depreciate_account: "Expenses:Car:Value"
 
 2022-03-31 * "Tesla" "Model X"
-  Liababilies:CreditCard:0001    -200000 USD
+  Liabilities:CreditCard:0001    -200000 USD
   Assets:Car:ModelX
     depreciate: "5 Year /Yearly =80000"
 
@@ -191,7 +191,7 @@ If step string ends with `!` means that the amount of every step will be calcula
 
 ```beancount
 2022-01-01 *
-  Liababilies:CreditCard:0001    -365 USD
+  Liabilities:CreditCard:0001    -365 USD
   Expenses:BlaBla
     amortize: "1 Year /Monthly!"
 ```
@@ -200,7 +200,7 @@ Then this plugin will transform the transaction into:
 
 ```beancount
 2022-01-01 *
-  Liababilies:CreditCard:0001    -365 USD
+  Liabilities:CreditCard:0001    -365 USD
   Expenses:BlaBla
     amortize: "1 Year /Monthly!"
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,26 @@ To change the depreciation expense account, add the `depreciate_account` meta to
 ; ...
 ```
 
+### Plugin Configuration
+All plugins support the following configuration options, which can be specified in the `plugin` directive:
+```beancount
+plugin "beancount_periodic.recur" "{...}"
+plugin "beancount_periodic.amortize" "{...}"
+plugin "beancount_periodic.depreciate" "{...}"
+```
+
+#### generate_until
+The `generate_until` configuration option prevents the plugin from generating transactions which occur after the given date.
+It supports a ISO 8601 date string or the string literal 'today', which is replaced with today's date.
+
+```beancount
+; the plugin will only generate transactions until today
+plugin "beancount_periodic.amortize" "{'generate_until':'today'}"
+
+; the plugin will only generate transactions up until (including) 2025-01-01
+plugin "beancount_periodic.amortize" "{'generate_until':'2025-01-01'}"
+```
+
 ### Config string in meta
 
 All settings follow the same rules. These are some examples:

--- a/beancount_periodic/amortize.py
+++ b/beancount_periodic/amortize.py
@@ -1,6 +1,7 @@
 from beancount.core import data, account, account_types
 from beancount.parser import options
 
+from .common.config import PluginConfig
 from .common.utils import build_steps
 from .common.utils import create_meta
 from .common.utils import select_periodic_posting_groups
@@ -9,6 +10,7 @@ __plugins__ = ('amortize',)
 
 
 def amortize(entries: data.Entries, unused_options_map, config_string=""):
+    plugin_config = PluginConfig.from_string(config_string)
     new_entries = []
     errors = []
     account_types_option = options.get_account_types(unused_options_map)
@@ -49,7 +51,7 @@ def amortize(entries: data.Entries, unused_options_map, config_string=""):
 
                 new_entries.extend(
                     build_steps('amortize', entry, new_postings_config, positive=True,
-                                narration_suffix='Amortized(%d/%d)'))
+                                narration_suffix='Amortized(%d/%d)', generate_until=plugin_config.generate_until))
 
             postings_to_insert_original_entry.reverse()
             for i, element in postings_to_insert_original_entry:

--- a/beancount_periodic/common/config.py
+++ b/beancount_periodic/common/config.py
@@ -1,7 +1,9 @@
 import datetime
 import re
 import sys
-from typing import Tuple
+import ast
+from typing import Tuple, Optional
+from dataclasses import dataclass
 
 from . import *
 
@@ -249,3 +251,28 @@ def __print_config_match_result(date_end, date_start, formula, num, step_named, 
     # sys.stderr.write('value: %s\n' % value)
     # sys.stderr.write('formula: %s\n' % ear)
     pass
+
+
+@dataclass
+class PluginConfig:
+    generate_until: Optional[datetime.date] = None
+
+    @staticmethod
+    def from_string(config_str: str) -> 'PluginConfig':
+        ret = PluginConfig()
+
+        if not config_str:
+            return ret
+        config_dict = ast.literal_eval(config_str)
+
+        try:
+            generate_until_str = config_dict.get('generate_until', None)
+            if generate_until_str == 'today':
+                ret.generate_until = datetime.date.today()
+            elif generate_until_str:
+                ret.generate_until = datetime.date.fromisoformat(generate_until_str)
+        except (ValueError, TypeError):
+            raise RuntimeError('Bad "generate_until" value - it must be a valid date, formatted in ISO 8601 (e.g. '
+                               '"2024-12-31") or the literal "today".')
+
+        return ret

--- a/beancount_periodic/common/utils.py
+++ b/beancount_periodic/common/utils.py
@@ -1,5 +1,6 @@
 import datetime
 from decimal import Decimal
+from typing import Optional
 
 from beancount.core import data
 
@@ -40,7 +41,8 @@ def select_periodic_posting_groups(entry, meta_name, errors):
 
 
 def build_steps(meta_key, entry, new_postings_config, positive=True,
-                narration_suffix='(% d / % d)'):
+                narration_suffix='(% d / % d)',
+                generate_until: Optional[datetime.date] = None):
     new_entries = []
 
     if len(new_postings_config) == 1:
@@ -71,6 +73,10 @@ def build_steps(meta_key, entry, new_postings_config, positive=True,
         round_remainder = Decimal('0')
         step_num = sum_step_ratio(config)
         for step_i, (step_days, step_ratio) in enumerate(config.steps):
+            # skip all steps that are past the given date
+            if generate_until and start_date > generate_until:
+                break
+
             if step_i < len(config.steps) - 1:
                 if config.equal_amount:
                     step_amount, remainder = round_and_remainder(step_ratio * total / step_num, place_num)

--- a/beancount_periodic/depreciate.py
+++ b/beancount_periodic/depreciate.py
@@ -4,6 +4,7 @@ import beancount.core.getters
 from beancount.core import data, account, account_types
 from beancount.parser import options
 
+from .common.config import PluginConfig
 from .common.utils import build_steps
 from .common.utils import select_periodic_posting_groups
 
@@ -31,6 +32,7 @@ def get_depreciation_account(
 
 
 def depreciate(entries: data.Entries, unused_options_map, config_string=""):
+    plugin_config = PluginConfig.from_string(config_string)
     new_entries = []
     errors = []
     account_types_option = options.get_account_types(unused_options_map)
@@ -55,7 +57,8 @@ def depreciate(entries: data.Entries, unused_options_map, config_string=""):
                 new_entries.extend(
                     build_steps('depreciate', entry, new_postings_config,
                                 positive=False,
-                                narration_suffix='Depreciated(%d/%d)'))
+                                narration_suffix='Depreciated(%d/%d)',
+                                generate_until=plugin_config.generate_until))
 
     if new_entries:
         entries.extend(new_entries)

--- a/beancount_periodic/recur.py
+++ b/beancount_periodic/recur.py
@@ -6,13 +6,13 @@ from beancount.parser import options
 
 from .common.utils import create_meta
 from .common.utils import create_step_entry
-from .common.config import parse
-
+from .common.config import parse, PluginConfig
 
 __plugins__ = ('recur',)
 
 
 def recur(entries: data.Entries, unused_options_map, config_string=""):
+    plugin_config = PluginConfig.from_string(config_string)
     new_entries = []
     errors = []
     account_types_option = options.get_account_types(unused_options_map)
@@ -29,6 +29,10 @@ def recur(entries: data.Entries, unused_options_map, config_string=""):
                     new_entry_narration_template = (entry.narration + ' ' if entry.narration else '') + 'Recurring(%d/%d)'
                     
                     for step_i, (step_days, step_ratio) in enumerate(entry_config.steps):
+                        # skip all steps that are past the given date
+                        if plugin_config.generate_until and start_date > plugin_config.generate_until:
+                            break
+
                         new_entry_narration = new_entry_narration_template % (step_i + 1, len(entry_config.steps))
                         end_date = start_date + datetime.timedelta(days=step_days)
 

--- a/tests/test_amortize.py
+++ b/tests/test_amortize.py
@@ -1,0 +1,97 @@
+import datetime
+import unittest
+
+from beancount.core.compare import compare_entries
+from beancount.core.data import Transaction
+from beancount.loader import load_string
+
+import tests.util
+
+
+def tx_normal(date: datetime.date, narration: str) -> Transaction:
+    return tests.util.make_transaction(
+        date=date,
+        payee='Landlord',
+        narration=narration,
+        account_from='Liabilities:CreditCard:0001',
+        account_to='Equity:Amortization:Home:Rent',
+        amount='12000',
+    )
+
+
+def tx_amortized(date: datetime.date, narration: str) -> Transaction:
+    return tests.util.make_transaction(
+        date=date,
+        payee='Landlord',
+        narration=narration,
+        account_from='Equity:Amortization:Home:Rent',
+        account_to='Expenses:Home:Rent',
+        amount='1000',
+    )
+
+
+class AmortizeTest(unittest.TestCase):
+    def test_simple(self):
+        journal_str = """
+plugin "beancount_periodic.amortize"
+1900-01-01 open Liabilities:CreditCard:0001 USD
+1900-01-01 open Expenses:Home:Rent USD
+1900-01-01 open Equity:Amortization:Home:Rent USD
+2022-03-31 * "Landlord" "2022-04 Rent"
+  Liabilities:CreditCard:0001    -12000 USD
+  Expenses:Home:Rent
+    amortize: "1 Year @2022-04-01 /Monthly"
+"""
+        entries, errors, options_map = load_string(journal_str)
+        self.assertEqual(len(errors), 0)
+
+        expected_entries = [
+            tx_normal(datetime.date(2022, 3, 31), '2022-04 Rent'),
+            tx_amortized(datetime.date(2022, 4, 1), '2022-04 Rent Amortized(1/12)'),
+            tx_amortized(datetime.date(2022, 5, 1), '2022-04 Rent Amortized(2/12)'),
+            tx_amortized(datetime.date(2022, 6, 1), '2022-04 Rent Amortized(3/12)'),
+            tx_amortized(datetime.date(2022, 7, 1), '2022-04 Rent Amortized(4/12)'),
+            tx_amortized(datetime.date(2022, 8, 1), '2022-04 Rent Amortized(5/12)'),
+            tx_amortized(datetime.date(2022, 9, 1), '2022-04 Rent Amortized(6/12)'),
+            tx_amortized(datetime.date(2022, 10, 1), '2022-04 Rent Amortized(7/12)'),
+            tx_amortized(datetime.date(2022, 11, 1), '2022-04 Rent Amortized(8/12)'),
+            tx_amortized(datetime.date(2022, 12, 1), '2022-04 Rent Amortized(9/12)'),
+            tx_amortized(datetime.date(2023, 1, 1), '2022-04 Rent Amortized(10/12)'),
+            tx_amortized(datetime.date(2023, 2, 1), '2022-04 Rent Amortized(11/12)'),
+            tx_amortized(datetime.date(2023, 3, 1), '2022-04 Rent Amortized(12/12)'),
+        ]
+
+        same, missing1, missing2 = compare_entries(list(tests.util.get_transactions_cleaned(entries)), expected_entries)
+        self.assertTrue(same)
+
+    def test_generate_until_01(self):
+        journal_str = """
+plugin "beancount_periodic.amortize" "{'generate_until':'2022-10-01'}"
+1900-01-01 open Liabilities:CreditCard:0001 USD
+1900-01-01 open Expenses:Home:Rent USD
+1900-01-01 open Equity:Amortization:Home:Rent USD
+2022-03-31 * "Landlord" "2022-04 Rent"
+  Liabilities:CreditCard:0001    -12000 USD
+  Expenses:Home:Rent
+    amortize: "1 Year @2022-04-01 /Monthly"
+        """
+        entries, errors, options_map = load_string(journal_str)
+        self.assertEqual(len(errors), 0)
+
+        expected_entries = [
+            tx_normal(datetime.date(2022, 3, 31), '2022-04 Rent'),
+            tx_amortized(datetime.date(2022, 4, 1), '2022-04 Rent Amortized(1/12)'),
+            tx_amortized(datetime.date(2022, 5, 1), '2022-04 Rent Amortized(2/12)'),
+            tx_amortized(datetime.date(2022, 6, 1), '2022-04 Rent Amortized(3/12)'),
+            tx_amortized(datetime.date(2022, 7, 1), '2022-04 Rent Amortized(4/12)'),
+            tx_amortized(datetime.date(2022, 8, 1), '2022-04 Rent Amortized(5/12)'),
+            tx_amortized(datetime.date(2022, 9, 1), '2022-04 Rent Amortized(6/12)'),
+            tx_amortized(datetime.date(2022, 10, 1), '2022-04 Rent Amortized(7/12)'),
+        ]
+
+        same, missing1, missing2 = compare_entries(list(tests.util.get_transactions_cleaned(entries)), expected_entries)
+        self.assertTrue(same)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_depreciate.py
+++ b/tests/test_depreciate.py
@@ -1,0 +1,86 @@
+import datetime
+import unittest
+
+from beancount.core.compare import compare_entries
+from beancount.core.data import Transaction
+from beancount.loader import load_string
+
+import tests.util
+
+
+def tx_normal(date: datetime.date, narration: str) -> Transaction:
+    return tests.util.make_transaction(
+        date=date,
+        payee='Tesla',
+        narration=narration,
+        account_from='Liabilities:CreditCard:0001',
+        account_to='Assets:Car:ModelX',
+        amount='200000',
+    )
+
+
+def tx_depreciated(date: datetime.date, narration: str) -> Transaction:
+    return tests.util.make_transaction(
+        date=date,
+        payee='Tesla',
+        narration=narration,
+        account_from='Assets:Car:ModelX',
+        account_to='Expenses:Depreciation:Car:ModelX',
+        amount='24000',
+    )
+
+
+class DepreciateTest(unittest.TestCase):
+    def test_simple(self):
+        journal_str = """
+plugin "beancount_periodic.depreciate"
+1900-01-01 open Liabilities:CreditCard:0001 USD
+1900-01-01 open Assets:Car:ModelX USD
+1900-01-01 open Expenses:Depreciation:Car:ModelX USD
+2022-03-31 * "Tesla" "Model X"
+  Liabilities:CreditCard:0001    -200000 USD
+  Assets:Car:ModelX
+    depreciate: "5 Year /Yearly =80000"
+"""
+        entries, errors, options_map = load_string(journal_str)
+        self.assertEqual(len(errors), 0)
+
+        expected_entries = [
+            tx_normal(datetime.date(2022, 3, 31), 'Model X'),
+            tx_depreciated(datetime.date(2022, 3, 31), 'Model X Depreciated(1/5)'),
+            tx_depreciated(datetime.date(2023, 3, 31), 'Model X Depreciated(2/5)'),
+            tx_depreciated(datetime.date(2024, 3, 31), 'Model X Depreciated(3/5)'),
+            tx_depreciated(datetime.date(2025, 3, 31), 'Model X Depreciated(4/5)'),
+            tx_depreciated(datetime.date(2026, 3, 31), 'Model X Depreciated(5/5)'),
+        ]
+
+        same, missing1, missing2 = compare_entries(list(tests.util.get_transactions_cleaned(entries)), expected_entries)
+        self.assertTrue(same)
+
+    def test_generate_until_01(self):
+        journal_str = """
+plugin "beancount_periodic.depreciate" "{'generate_until':'2024-03-31'}"
+1900-01-01 open Liabilities:CreditCard:0001 USD
+1900-01-01 open Assets:Car:ModelX USD
+1900-01-01 open Expenses:Depreciation:Car:ModelX USD
+2022-03-31 * "Tesla" "Model X"
+  Liabilities:CreditCard:0001    -200000 USD
+  Assets:Car:ModelX
+    depreciate: "5 Year /Yearly =80000"
+        """
+        entries, errors, options_map = load_string(journal_str)
+        self.assertEqual(len(errors), 0)
+
+        expected_entries = [
+            tx_normal(datetime.date(2022, 3, 31), 'Model X'),
+            tx_depreciated(datetime.date(2022, 3, 31), 'Model X Depreciated(1/5)'),
+            tx_depreciated(datetime.date(2023, 3, 31), 'Model X Depreciated(2/5)'),
+            tx_depreciated(datetime.date(2024, 3, 31), 'Model X Depreciated(3/5)'),
+        ]
+
+        same, missing1, missing2 = compare_entries(list(tests.util.get_transactions_cleaned(entries)), expected_entries)
+        self.assertTrue(same)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_recur.py
+++ b/tests/test_recur.py
@@ -1,0 +1,84 @@
+import datetime
+import unittest
+
+from beancount.core.compare import compare_entries
+from beancount.core.data import Transaction
+from beancount.loader import load_string
+
+import tests.util
+
+
+def tx_recurring(date: datetime.date, narration: str) -> Transaction:
+    return tests.util.make_transaction(
+        date=date,
+        payee='Provider',
+        narration=narration,
+        account_from='Liabilities:CreditCard:0001',
+        account_to='Expenses:Home:CommunicationFee',
+        amount='50',
+    )
+
+
+class RecurTest(unittest.TestCase):
+    def test_simple(self):
+        journal_str = """
+plugin "beancount_periodic.recur"
+1900-01-01 open Liabilities:CreditCard:0001 USD
+1900-01-01 open Expenses:Home:CommunicationFee USD
+2022-03-31 * "Provider" "Net Fee"
+  recur: "1 Year /Monthly"
+  Liabilities:CreditCard:0001    -50 USD
+  Expenses:Home:CommunicationFee
+"""
+        entries, errors, options_map = load_string(journal_str)
+        self.assertEqual(len(errors), 0)
+
+        expected_entries = [
+            tx_recurring(datetime.date(2022, 3, 31), 'Net Fee Recurring(1/12)'),
+            tx_recurring(datetime.date(2022, 4, 30), 'Net Fee Recurring(2/12)'),
+            tx_recurring(datetime.date(2022, 5, 31), 'Net Fee Recurring(3/12)'),
+            tx_recurring(datetime.date(2022, 6, 30), 'Net Fee Recurring(4/12)'),
+            tx_recurring(datetime.date(2022, 7, 31), 'Net Fee Recurring(5/12)'),
+            tx_recurring(datetime.date(2022, 8, 31), 'Net Fee Recurring(6/12)'),
+            tx_recurring(datetime.date(2022, 9, 30), 'Net Fee Recurring(7/12)'),
+            tx_recurring(datetime.date(2022, 10, 31), 'Net Fee Recurring(8/12)'),
+            tx_recurring(datetime.date(2022, 11, 30), 'Net Fee Recurring(9/12)'),
+            tx_recurring(datetime.date(2022, 12, 31), 'Net Fee Recurring(10/12)'),
+            tx_recurring(datetime.date(2023, 1, 31), 'Net Fee Recurring(11/12)'),
+            tx_recurring(datetime.date(2023, 2, 28), 'Net Fee Recurring(12/12)'),
+        ]
+
+        same, missing1, missing2 = compare_entries(list(tests.util.get_transactions_cleaned(entries)), expected_entries)
+        self.assertTrue(same)
+
+    def test_generate_until_01(self):
+        journal_str = """
+plugin "beancount_periodic.recur" "{'generate_until':'2022-11-30'}"
+1900-01-01 open Liabilities:CreditCard:0001 USD
+1900-01-01 open Expenses:Home:CommunicationFee USD
+2022-03-31 * "Provider" "Net Fee"
+  recur: "1 Year /Monthly"
+  Liabilities:CreditCard:0001    -50 USD
+  Expenses:Home:CommunicationFee
+"""
+        entries, errors, options_map = load_string(journal_str)
+        self.assertEqual(len(errors), 0)
+
+        expected_entries = [
+            tx_recurring(datetime.date(2022, 3, 31), 'Net Fee Recurring(1/12)'),
+            tx_recurring(datetime.date(2022, 4, 30), 'Net Fee Recurring(2/12)'),
+            tx_recurring(datetime.date(2022, 5, 31), 'Net Fee Recurring(3/12)'),
+            tx_recurring(datetime.date(2022, 6, 30), 'Net Fee Recurring(4/12)'),
+            tx_recurring(datetime.date(2022, 7, 31), 'Net Fee Recurring(5/12)'),
+            tx_recurring(datetime.date(2022, 8, 31), 'Net Fee Recurring(6/12)'),
+            tx_recurring(datetime.date(2022, 9, 30), 'Net Fee Recurring(7/12)'),
+            tx_recurring(datetime.date(2022, 10, 31), 'Net Fee Recurring(8/12)'),
+            tx_recurring(datetime.date(2022, 11, 30), 'Net Fee Recurring(9/12)'),
+        ]
+
+        same, missing1, missing2 = compare_entries(list(tests.util.get_transactions_cleaned(entries)), expected_entries)
+        self.assertTrue(same)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,55 @@
+import datetime
+from decimal import Decimal
+from typing import List
+
+from beancount.core.amount import Amount
+from beancount.core.data import Transaction, Posting
+
+
+def get_transactions_cleaned(entries: List) -> List[Transaction]:
+    for e in entries:
+        if not isinstance(e, Transaction):
+            continue
+        e = e._replace(meta={'lineno': 0})
+        e = e._replace(postings=[
+            p._replace(meta={'lineno': 0}) for p in e.postings
+        ])
+        yield e
+
+
+def make_transaction(date: datetime.date, payee: str, narration: str, account_from: str, account_to: str,
+                     amount: str) -> Transaction:
+    tx = Transaction(
+        date=date,
+        flag='*',
+        payee=payee,
+        narration=narration,
+        postings=[
+            Posting(
+                account=account_from,
+                units=Amount(
+                    number=-Decimal(amount),
+                    currency='USD'
+                ),
+                cost=None,
+                price=None,
+                flag=None,
+                meta={'lineno': 0},
+            ),
+            Posting(
+                account=account_to,
+                units=Amount(
+                    number=Decimal(amount),
+                    currency='USD'
+                ),
+                cost=None,
+                price=None,
+                flag=None,
+                meta={'lineno': 0},
+            ),
+        ],
+        meta={'lineno': 0},
+        tags=[],
+        links=[],
+    )
+    return tx


### PR DESCRIPTION
This pull request adds the configuration option `generate_until`, which allows specification of a date after which no transactions shall be generated. The behavior of the plugin without any configuration remains unchanged: it generates all transactions, without any date limits.

This allows me to use the plugin with Fava, which by default shows all future transactions. I use it like this:
```beancount
plugin "beancount_periodic.depreciate" "{'generate_until':'today'}"
```

I re-created the examples from the README.md in some test cases and tested the behavior of the `generate_until` option.

Closes #2 

