### PR TITLE
feat: Split transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,45 @@ Then this plugin will transform the transaction into:
   Expenses:Home:CommunicationFee
 ```
 
+### `split`
+
+Similar to recur, except instead of just repeating the same transaction
+multiple times, the original transaction is split into multiple, smaller
+transactions that sum up to the same postings as the original.
+
+`main.bean`
+```
+plugin "beancount_periodic.split"
+```
+
+```beancount
+2025-01-01 * "Tax Estimate"
+    split: "Year / Monthly"
+    Liabilities:Tax
+    Expenses:Tax:Income 12000.00 USD
+```
+
+Then this plugin will transform the transaction into:
+
+```beancount
+; The amounts are not simply 1000 USD per month, since some months are longer
+; than others
+2025-01-01 * "Tax Estimate Split(1/12)"
+    Liabilities:Tax -1019.178082191780821917808219 USD
+    Expenses:Tax:Income 1019.178082191780821917808219 USD
+
+2025-02-01 * "Tax Estimate Split(2/12)"
+    Liabilities:Tax -920.5479452054794520547945205 CHF 
+    Expenses:Tax:Income 920.5479452054794520547945205 CHF
+
+;...
+
+2025-12-01 * "Tax Estimate Split(1/12)"
+    Liabilities:Tax -1019.178082191780821917808219 USD
+    Expenses:Tax:Income 1019.178082191780821917808219 USD
+
+```
+
 #### `amortize`
 
 `main.bean`

--- a/beancount_periodic/split.py
+++ b/beancount_periodic/split.py
@@ -1,0 +1,97 @@
+import datetime
+from decimal import Decimal
+from typing import List, Tuple, Optional
+
+from beancount.core import data, account, account_types
+from beancount.parser import options
+
+from .common.utils import create_meta
+from .common.utils import create_step_entry
+from .common.config import parse, PluginConfig, PeriodicConfig
+
+__plugins__ = ("split",)
+
+
+def _create_split_step(entry, step_i, total_steps, date, step_multiplier, entry_meta):
+    new_entry_narration = (entry.narration + " " if entry.narration else "") + f"Split({step_i + 1}/{total_steps})"
+    
+    return create_step_entry(
+        entry,
+        date,
+        entry_meta,
+        new_entry_narration,
+        [
+            posting._replace(
+                units=data.Amount(
+                    posting.units.number * step_multiplier,
+                    posting.units.currency,
+                )
+            )
+            for posting in entry.postings
+        ],
+    )
+
+
+def _split_entry(entry: data.Transaction, plugin_config: PluginConfig) -> Tuple[List[data.Transaction], List[str]]:
+    entry_config, entry_config_err = parse(
+        entry.meta.get("split"),
+        Decimal("0"),
+        entry.date,
+        "M",
+        "D",
+        Decimal("0"),
+        "line",
+    )
+    if not entry_config:
+        return [], [entry_config_err._replace(source=entry.meta)]
+
+    new_entries = []
+    new_entry_meta = create_meta(entry.meta, deletions=["split", "narration"])
+    start_date = entry_config.start
+    total_days = Decimal(sum(step_days for (step_days, _) in entry_config.steps))
+
+    for step_i, (step_days, step_ratio) in enumerate(entry_config.steps):
+        # skip all steps that are past the given date
+        if plugin_config.generate_until and start_date > plugin_config.generate_until:
+            break
+
+        new_entry = _create_split_step(
+            entry,
+            step_i,
+            len(entry_config.steps),
+            start_date,
+            step_days / total_days,
+            new_entry_meta,
+        )
+        new_entries.append(new_entry)
+        start_date += datetime.timedelta(days=step_days)
+
+    return new_entries, []
+
+
+def split(entries: data.Entries, unused_options_map, config_string=""):
+    plugin_config = PluginConfig.from_string(config_string)
+    new_entries = []
+    errors = []
+    entries_to_remove = []
+    splittable_entries = [
+        entry
+        for entry in entries
+        if isinstance(entry, data.Transaction) and entry.meta and "split" in entry.meta
+    ]
+
+    for entry in splittable_entries:
+        entry_new_entries, entry_errors = _split_entry(entry, plugin_config)
+        new_entries.extend(entry_new_entries)
+        errors.extend(entry_errors)
+        if entry_new_entries:  # Only remove the original entry if we created new ones
+            entries_to_remove.append(entry)
+
+    for entry_to_remove in entries_to_remove:
+        entries.remove(entry_to_remove)
+
+    if new_entries:
+        entries.extend(new_entries)
+        entries.sort(key=data.entry_sortkey)
+
+    return entries, errors


### PR DESCRIPTION
This is kind of a blend between 'recur' and 'amortize'. It splits a single transaction into multiple smaller ones, but without booking any equity.

My specific use case, hinted at in the README, is taxes. I'm in Switzerland, and I don't get any tax withheld from my income, but I'm able to estimate how much tax I'll owe for a given tax year (based on my estimation of income for that tax year). Splitting the transaction like this lets me have a single transaction per year that I can go to and update based on changes to my income estimations. If I had a single, unsplit transaction, it completely messes up balance sheet views. Amortize messes it up as well, since it books equity.