### PR TITLE
feat: adapt to beancount v3 by updating import for parse_date_liberally

### DIFF
--- a/beancount_periodic/common/config.py
+++ b/beancount_periodic/common/config.py
@@ -12,7 +12,7 @@ from dateutil.relativedelta import relativedelta
 try:
     from beancount.utils.date_utils import parse_date_liberally
 except ImportError:
-    from beangulp.date_utils import parse_date_liberally
+    from beangulp.date_utils import parse_date as parse_date_liberally
 
 RE_TOTAL = '\\s*(?P<total>\\d+(?:\\.\\d+)?)\\s*-'
 PART_DURATION_NAMED = "(?:Day|Week|Month|Quarter|Year)"


### PR DESCRIPTION
beangulp provides `parse_date` function. To ensure compatibility, updated the fallback import to use `parse_date` from the `beangulp.date_utils` module, aliasing it as `parse_date_liberally`.

https://github.com/beancount/beangulp/blob/v0.1.1/beangulp/date_utils.py#L4

Changes:
- If `beancount.utils.date_utils.parse_date_liberally` is unavailable, fallback now imports `beangulp.date_utils.parse_date` as `parse_date_liberally`.

This change maintains backward compatibility and supports environments using Beancount v3.

via [beancount/beangulp@6147957](https://github.com/beancount/beangulp/commit/61479575c8d2a0c9b7478e6dec765d507b97ebae), #7