### PR TITLE
Also catch ModuleNotFoundError when failing to import beancount.utils.date_utils

### DIFF
--- a/beancount_periodic/common/config.py
+++ b/beancount_periodic/common/config.py
@@ -11,7 +11,7 @@ from dateutil.relativedelta import relativedelta
 
 try:
     from beancount.utils.date_utils import parse_date_liberally
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     from beangulp.date_utils import parse_date as parse_date_liberally
 
 RE_TOTAL = '\\s*(?P<total>\\d+(?:\\.\\d+)?)\\s*-'


### PR DESCRIPTION
Fixes https://github.com/yegle/fava-docker/issues/63