### PR TITLE
Add fractional year support and auto-open directives for depreciation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 ﻿.idea
-*/__pycache__
+__pycache__/
+*/__pycache__/
 *.egg-info
 dist
 venv
+.venv
+.claude/

--- a/beancount_periodic/common/config.py
+++ b/beancount_periodic/common/config.py
@@ -17,7 +17,7 @@ except (ImportError, ModuleNotFoundError):
 RE_TOTAL = '\\s*(?P<total>\\d+(?:\\.\\d+)?)\\s*-'
 PART_DURATION_NAMED = "(?:Day|Week|Month|Quarter|Year)"
 PART_DURATION_NAMED_SHORTEN = "[DWMQY]"
-DURATION_NUM = f'(?P<num>\\d+)?\\s*(?:(?P<unit_named>{PART_DURATION_NAMED}s?)|(?P<unit_named_shorten>' \
+DURATION_NUM = f'(?P<num>\\d+(?:\\.\\d+)?)?\\s*(?:(?P<unit_named>{PART_DURATION_NAMED}s?)|(?P<unit_named_shorten>' \
                f'{PART_DURATION_NAMED_SHORTEN}))?'
 RE_DATE_START = "@\\s*(?P<date_start>\\d{4}-\\d{2}-\\d{2})"
 RE_DATE_END = "~\\s*(?P<date_end>\\d{4}-\\d{2}-\\d{2})"
@@ -36,6 +36,19 @@ CONFIG_STR_PATTERN_DURATION = re.compile(fr'{RE_DURATION}')
 CONFIG_STR_PATTERN_STEP = re.compile(fr'{RE_STEP}')
 
 
+def _get_duration_from_months(start_date, total_months):
+    """
+    Calculate the number of days from a (possibly fractional) number of months.
+    Fractional months are approximated as 30 days per month.
+    """
+    whole_months = int(total_months)
+    fractional_part = total_months - whole_months
+    delta = (start_date + relativedelta(months=whole_months)) - start_date
+    if fractional_part > 0:
+        return delta.days + int(fractional_part * 30)
+    return delta.days
+
+
 def get_duration(start_date, num, unit_named, unit_named_shorten):
     """
     Calculate the number of days by natural date
@@ -49,21 +62,17 @@ def get_duration(start_date, num, unit_named, unit_named_shorten):
     if unit:
         key_letter = unit[:1]
         if key_letter == 'D':
-            return 1 * num
+            return int(num)
         elif key_letter == 'W':
-            return 7 * num
+            return int(7 * num)
         elif key_letter == 'M':
-            delta = (start_date + relativedelta(months=num)) - start_date
-            return delta.days
+            return _get_duration_from_months(start_date, num)
         elif key_letter == 'Q':
-            delta = (start_date + relativedelta(months=num * 3)) - start_date
-            return delta.days
-            pass
+            return _get_duration_from_months(start_date, num * 3)
         elif key_letter == 'Y':
-            delta = (start_date + relativedelta(years=num)) - start_date
-            return delta.days
+            return _get_duration_from_months(start_date, num * 12)
     else:
-        return num
+        return int(num)
 
 
 def get_steps(start_date, duration, num, unit_named, unit_named_shorten):
@@ -80,9 +89,9 @@ def get_steps(start_date, duration, num, unit_named, unit_named_shorten):
     if unit:
         key_letter = unit[:1]
         if key_letter == 'D':
-            return get_steps_simple(duration, num)
+            return get_steps_simple(duration, int(num))
         elif key_letter == 'W':
-            return get_steps_simple(duration, 7 * num)
+            return get_steps_simple(duration, int(7 * num))
         elif key_letter == 'M':
             return __get_steps(start_date, duration, lambda i: relativedelta(months=i))
         elif key_letter == 'Q':
@@ -90,7 +99,7 @@ def get_steps(start_date, duration, num, unit_named, unit_named_shorten):
         elif key_letter == 'Y':
             return __get_steps(start_date, duration, lambda i: relativedelta(years=i))
     else:
-        return get_steps_simple(duration, num)
+        return get_steps_simple(duration, int(num))
 
 
 def get_steps_simple(duration, step):
@@ -180,7 +189,7 @@ def parse(
             start_date = parse_date_liberally(date_start, {}) if date_start else default_start_date
 
             if num or unit_named or unit_named_shorten:
-                num = int(num) if num else 1
+                num = Decimal(num) if num else Decimal('1')
                 duration = get_duration(start_date, num, unit_named, unit_named_shorten)
             elif date_end:
                 duration = (parse_date_liberally(date_end, {}) - start_date).days
@@ -190,7 +199,7 @@ def parse(
                     num = duration_math.group('num')
                     unit_named = duration_math.group('unit_named')
                     unit_named_shorten = duration_math.group('unit_named_shorten')
-                    num = int(num) if num else 1
+                    num = Decimal(num) if num else Decimal('1')
                     duration = get_duration(start_date, num, unit_named, unit_named_shorten)
                 else:
                     return None, PeriodicConfigError(None, 'fail to parse default duration: %s' % default_duration_str,

--- a/beancount_periodic/depreciate.py
+++ b/beancount_periodic/depreciate.py
@@ -37,6 +37,9 @@ def depreciate(entries: data.Entries, unused_options_map, config_string=""):
     errors = []
     account_types_option = options.get_account_types(unused_options_map)
     accounts_open_close = beancount.core.getters.get_account_open_close(entries)
+    # Track accounts we've generated open directives for to avoid duplicates
+    generated_open_accounts = set()
+
     for entry in entries:
         if isinstance(entry, data.Transaction):
             selected_postings_groups = select_periodic_posting_groups(entry, 'depreciate', errors)
@@ -52,6 +55,22 @@ def depreciate(entries: data.Entries, unused_options_map, config_string=""):
                         )
                     else:
                         continue
+
+                    # Auto-generate Open directive if the account doesn't exist
+                    if new_account not in accounts_open_close and new_account not in generated_open_accounts:
+                        open_directive = data.Open(
+                            account=new_account,
+                            currencies=[posting.units.currency] if posting.units and posting.units.currency else None,
+                            booking=None,
+                            date=entry.date,
+                            meta=data.new_metadata(
+                                entry.meta.get('filename', '<generated>'),
+                                entry.meta.get('lineno', 0)
+                            )
+                        )
+                        new_entries.append(open_directive)
+                        generated_open_accounts.add(new_account)
+
                     new_postings_config.append((config, posting, new_account))
 
                 new_entries.extend(

--- a/tests/test_depreciate.py
+++ b/tests/test_depreciate.py
@@ -1,8 +1,9 @@
 import datetime
 import unittest
+from decimal import Decimal
 
 from beancount.core.compare import compare_entries
-from beancount.core.data import Transaction
+from beancount.core.data import Transaction, Open
 from beancount.loader import load_string
 
 import tests.util
@@ -80,6 +81,160 @@ plugin "beancount_periodic.depreciate" "{'generate_until':'2024-03-31'}"
 
         same, missing1, missing2 = compare_entries(list(tests.util.get_transactions_cleaned(entries)), expected_entries)
         self.assertTrue(same)
+
+    def test_fractional_year_half(self):
+        """Test 0.5 Year depreciation (6 months) with auto-open"""
+        journal_str = """
+plugin "beancount_periodic.depreciate"
+1900-01-01 open Liabilities:CreditCard:0001 USD
+1900-01-01 open Assets:Car:ModelX USD
+2022-01-01 * "Tesla" "Model X"
+  Liabilities:CreditCard:0001    -12000 USD
+  Assets:Car:ModelX
+    depreciate: "0.5 Year /Monthly"
+"""
+        entries, errors, options_map = load_string(journal_str)
+        self.assertEqual(len(errors), 0)
+
+        # 0.5 Year with Monthly step should produce 6 depreciation transactions
+        depreciation_txns = [e for e in entries
+                             if isinstance(e, Transaction) and 'Depreciated' in e.narration]
+        self.assertEqual(len(depreciation_txns), 6)
+
+        # Verify auto-open was generated
+        open_directives = [e for e in entries if isinstance(e, Open)]
+        expense_opens = [o for o in open_directives if 'Depreciation' in o.account]
+        self.assertEqual(len(expense_opens), 1)
+        self.assertEqual(expense_opens[0].account, 'Expenses:Depreciation:Car:ModelX')
+
+    def test_fractional_year_27_5(self):
+        """Test 27.5 Year depreciation for real estate with auto-open"""
+        journal_str = """
+plugin "beancount_periodic.depreciate"
+1900-01-01 open Liabilities:Mortgage USD
+1900-01-01 open Assets:RealEstate:Building USD
+2022-01-01 * "Property" "Building Purchase"
+  Liabilities:Mortgage    -275000 USD
+  Assets:RealEstate:Building
+    depreciate: "27.5 Year /Yearly"
+"""
+        entries, errors, options_map = load_string(journal_str)
+        self.assertEqual(len(errors), 0)
+
+        # 27.5 years with Yearly step should produce 28 depreciation transactions
+        # (27 full years + 1 partial year)
+        depreciation_txns = [e for e in entries
+                             if isinstance(e, Transaction) and 'Depreciated' in e.narration]
+        self.assertEqual(len(depreciation_txns), 28)
+
+        # Verify auto-open was generated
+        open_directives = [e for e in entries if isinstance(e, Open)]
+        expense_opens = [o for o in open_directives if 'Depreciation' in o.account]
+        self.assertEqual(len(expense_opens), 1)
+        self.assertEqual(expense_opens[0].account, 'Expenses:Depreciation:RealEstate:Building')
+
+        # Get depreciation amounts from expense postings
+        def get_expense_amount(txn):
+            for p in txn.postings:
+                if 'Depreciation' in p.account:
+                    return p.units.number
+            return None
+
+        # The last transaction should be roughly half the amount of a full year
+        full_year_amount = get_expense_amount(depreciation_txns[0])
+        last_txn_amount = get_expense_amount(depreciation_txns[-1])
+        # Last transaction should be significantly less than a full year (roughly half)
+        self.assertLess(last_txn_amount, full_year_amount * Decimal('0.6'))
+
+    def test_auto_open_directive(self):
+        """Test that open directive is auto-generated for expense account"""
+        journal_str = """
+plugin "beancount_periodic.depreciate"
+1900-01-01 open Liabilities:CreditCard:0001 USD
+1900-01-01 open Assets:Car:ModelX USD
+2022-03-31 * "Tesla" "Model X"
+  Liabilities:CreditCard:0001    -200000 USD
+  Assets:Car:ModelX
+    depreciate: "5 Year /Yearly =80000"
+"""
+        entries, errors, options_map = load_string(journal_str)
+        self.assertEqual(len(errors), 0)
+
+        # Check that Open directive was generated for the expense account
+        open_directives = [e for e in entries if isinstance(e, Open)]
+        expense_opens = [o for o in open_directives if 'Depreciation' in o.account]
+        self.assertEqual(len(expense_opens), 1)
+        self.assertEqual(expense_opens[0].account, 'Expenses:Depreciation:Car:ModelX')
+        self.assertEqual(expense_opens[0].currencies, ['USD'])
+
+    def test_auto_open_no_duplicate(self):
+        """Test that no duplicate open directives are created"""
+        journal_str = """
+plugin "beancount_periodic.depreciate"
+1900-01-01 open Liabilities:CreditCard:0001 USD
+1900-01-01 open Assets:Car:ModelX USD
+1900-01-01 open Expenses:Depreciation:Car:ModelX USD
+2022-03-31 * "Tesla" "Model X"
+  Liabilities:CreditCard:0001    -200000 USD
+  Assets:Car:ModelX
+    depreciate: "5 Year /Yearly =80000"
+"""
+        entries, errors, options_map = load_string(journal_str)
+        self.assertEqual(len(errors), 0)
+
+        # When expense account already exists, no additional open should be created
+        open_directives = [e for e in entries if isinstance(e, Open)]
+        expense_opens = [o for o in open_directives if 'Depreciation' in o.account]
+        self.assertEqual(len(expense_opens), 1)  # Only the original one
+
+    def test_auto_open_multiple_assets(self):
+        """Test auto-open with multiple assets in same file"""
+        journal_str = """
+plugin "beancount_periodic.depreciate"
+1900-01-01 open Liabilities:CreditCard:0001 USD
+1900-01-01 open Assets:Car:ModelX USD
+1900-01-01 open Assets:Car:ModelY USD
+2022-03-31 * "Tesla" "Model X"
+  Liabilities:CreditCard:0001    -200000 USD
+  Assets:Car:ModelX
+    depreciate: "5 Year /Yearly =80000"
+2022-04-01 * "Tesla" "Model Y"
+  Liabilities:CreditCard:0001    -100000 USD
+  Assets:Car:ModelY
+    depreciate: "3 Year /Yearly =40000"
+"""
+        entries, errors, options_map = load_string(journal_str)
+        self.assertEqual(len(errors), 0)
+
+        # Check that separate Open directives were generated for each expense account
+        open_directives = [e for e in entries if isinstance(e, Open)]
+        expense_opens = [o for o in open_directives if 'Depreciation' in o.account]
+        self.assertEqual(len(expense_opens), 2)
+        expense_accounts = {o.account for o in expense_opens}
+        self.assertIn('Expenses:Depreciation:Car:ModelX', expense_accounts)
+        self.assertIn('Expenses:Depreciation:Car:ModelY', expense_accounts)
+
+    def test_custom_depreciate_account_auto_open(self):
+        """Test auto-open respects custom depreciate_account metadata"""
+        journal_str = """
+plugin "beancount_periodic.depreciate"
+1900-01-01 open Liabilities:CreditCard:0001 USD
+1900-01-01 open Assets:Car:ModelX USD
+  depreciate_account: "Expenses:Auto:Depreciation"
+2022-03-31 * "Tesla" "Model X"
+  Liabilities:CreditCard:0001    -200000 USD
+  Assets:Car:ModelX
+    depreciate: "5 Year /Yearly =80000"
+"""
+        entries, errors, options_map = load_string(journal_str)
+        self.assertEqual(len(errors), 0)
+
+        # Check that Open directive was generated for the custom expense account
+        open_directives = [e for e in entries if isinstance(e, Open)]
+        expense_opens = [o for o in open_directives if 'Depreciation' in o.account]
+        # Should have one auto-generated open for the custom account
+        custom_opens = [o for o in expense_opens if o.account == 'Expenses:Auto:Depreciation']
+        self.assertEqual(len(custom_opens), 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- **Fractional year support**: Enables depreciation schedules like `27.5 Year /Yearly` for IRS-standard residential rental property depreciation
- **Auto-open directives**: Automatically generates `Open` directives for depreciation expense accounts, eliminating manual account declarations

## Changes

### Fractional Year Support (`config.py`)
- Updated regex to capture decimal duration values (e.g., `27.5`)
- Parse duration numbers as `Decimal` instead of `int`
- Extracted `_get_duration_from_months()` helper for cleaner fractional handling
- Converts fractional years to months for precise calculation (27.5 years = 330 months)

### Auto-open Directives (`depreciate.py`)
- When a depreciation transaction references an expense account that doesn't exist, automatically create an `Open` directive
- Tracks generated accounts to prevent duplicates
- Uses transaction date for the `Open` directive
- Respects existing accounts and custom `depreciate_account` metadata

## Test plan

- [x] `test_fractional_year_half`: 0.5 Year generates 6 monthly depreciation entries
- [x] `test_fractional_year_27_5`: 27.5 Year generates 28 yearly entries with partial final amount
- [x] `test_auto_open_directive`: Open directive generated when expense account doesn't exist
- [x] `test_auto_open_no_duplicate`: No duplicate opens when account already exists
- [x] `test_auto_open_multiple_assets`: Works with multiple assets in same file
- [x] `test_custom_depreciate_account_auto_open`: Respects custom depreciate_account metadata
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)