### PR TITLE
Add minimal working pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This PR adds a minimal pyproject.toml following PEP 517/518, as recommended by python upstream in https://packaging.python.org/en/latest/tutorials/packaging-projects/ .